### PR TITLE
Fixed message id check

### DIFF
--- a/modules/translate/main.js
+++ b/modules/translate/main.js
@@ -78,7 +78,7 @@ module.exports = (bot, channel, user, args, id, message, extra) => {
         return channel.fetchMessages({ before: id, limit: 1 })
             .then(msg => translate(msg.first().content))
             .catch(error => util.error(error, "translate", channel));
-    } else if (/^[0-9]{18}$/.test(args[0])) {
+    } else if (Boolean(Number(args[0]))) {
         return channel.fetchMessage(args[0])
             .then(msg => translate(msg.content))
             .catch(error => util.error(error, "translate", channel));

--- a/modules/translate/main.js
+++ b/modules/translate/main.js
@@ -78,7 +78,7 @@ module.exports = (bot, channel, user, args, id, message, extra) => {
         return channel.fetchMessages({ before: id, limit: 1 })
             .then(msg => translate(msg.first().content))
             .catch(error => util.error(error, "translate", channel));
-    } else if (Number(args[0])) {
+    } else if (/^[0-9]{18}$/.test(args[0])) {
         return channel.fetchMessage(args[0])
             .then(msg => translate(msg.content))
             .catch(error => util.error(error, "translate", channel));


### PR DESCRIPTION
Tested and working.

P.S. When you give an 18 character number that isn't a message id it gives an error related to logging files
`Error: ENOENT: no such file or directory, open './logs/6_February_2017.log'`
Which crashes the bot and forces a restart. cuz pm2